### PR TITLE
Implement missing API features and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment configuration
+# Backend
+OPENAI_API_KEY=your_openai_api_key
+SUPABASE_PROJECT_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your_supabase_anon_key
+PORT=3000
+SUPABASE_CONNECT=TRUE
+ENABLE_CHATGPT_ENDPOINT=true
+DEBUG_MODE=false
+VERBOSE_STARTUP=false
+ENABLE_PORT_CLEANUP=true
+
+# Frontend
+VITE_API_URL=http://localhost:3000

--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -105,20 +105,46 @@ app.post("/api/assessment", async (req, res) => {
 app.get("/api/reports/:id", async (req, res) => {
   try {
     const { id } = req.params;
-    // TODO: Implement report fetch
-    res.json({ message: "Report endpoint ready" });
+    if (!supabase) {
+      return res.status(500).json({ error: "Supabase client not configured" });
+    }
+
+    const { data, error } = await supabase
+      .from("reports")
+      .select("*")
+      .eq("id", id)
+      .single();
+
+    if (error) throw error;
+    if (!data) return res.status(404).json({ error: "Report not found" });
+
+    res.json({ data });
   } catch (error) {
-    res.status(500).json({ error: "Failed to fetch report" });
+    console.error("Failed to fetch report:", error);
+    res.status(500).json({ error: error.message || "Failed to fetch report" });
   }
 });
 
 app.get("/api/profiles/:id", async (req, res) => {
   try {
     const { id } = req.params;
-    // TODO: Implement profile fetch
-    res.json({ message: "Profile endpoint ready" });
+    if (!supabase) {
+      return res.status(500).json({ error: "Supabase client not configured" });
+    }
+
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("*")
+      .eq("id", id)
+      .single();
+
+    if (error) throw error;
+    if (!data) return res.status(404).json({ error: "Profile not found" });
+
+    res.json({ data });
   } catch (error) {
-    res.status(500).json({ error: "Failed to fetch profile" });
+    console.error("Failed to fetch profile:", error);
+    res.status(500).json({ error: error.message || "Failed to fetch profile" });
   }
 });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -11,7 +11,13 @@ const { exec } = require("child_process");
 const util = require("util");
 const execPromise = util.promisify(exec);
 
-console.log("Starting CMO Assessment Tool backend...");
+const VERBOSE_STARTUP = process.env.VERBOSE_STARTUP === "true";
+const ENABLE_PORT_CLEANUP = process.env.ENABLE_PORT_CLEANUP !== "false";
+
+const vlog = (...args) => {
+  if (VERBOSE_STARTUP) console.log(...args);
+};
+vlog("Starting CMO Assessment Tool backend...");
 
 // List of required environment variables
 const requiredEnvVars = [
@@ -28,7 +34,9 @@ if (missingVars.length > 0) {
     `Missing required environment variables: ${missingVars.join(", ")}`
   );
 }
-console.log("✓ Environment variables validated");
+if (VERBOSE_STARTUP) {
+  vlog("✓ Environment variables validated");
+}
 
 // Check if Supabase connection is enabled
 if (process.env.SUPABASE_CONNECT === "TRUE") {
@@ -39,7 +47,9 @@ if (process.env.SUPABASE_CONNECT === "TRUE") {
       process.env.SUPABASE_PROJECT_URL,
       process.env.SUPABASE_ANON_KEY
     );
-    console.log("✓ Supabase client initialized");
+    if (VERBOSE_STARTUP) {
+      vlog("✓ Supabase client initialized");
+    }
   } catch (error) {
     console.error("❌ Failed to initialize Supabase client:", error);
     process.exit(1);
@@ -59,7 +69,7 @@ const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 // Function to check if port 3000 is in use and kill the process if needed
 const freeUpPort = async (port) => {
   try {
-    console.log(`Checking if port ${port} is in use...`);
+    vlog(`Checking if port ${port} is in use...`);
 
     // Command to find process using port 3000
     const findCommand =
@@ -70,7 +80,7 @@ const freeUpPort = async (port) => {
     const { stdout } = await execPromise(findCommand);
 
     if (stdout) {
-      console.log(`Port ${port} is in use. Attempting to free it up...`);
+      vlog(`Port ${port} is in use. Attempting to free it up...`);
 
       // Extract PID and kill the process
       let pid;
@@ -83,18 +93,18 @@ const freeUpPort = async (port) => {
       }
 
       if (pid) {
-        console.log(`Killing process with PID: ${pid}`);
+        vlog(`Killing process with PID: ${pid}`);
         const killCommand =
           process.platform === "win32"
             ? `taskkill /F /PID ${pid}`
             : `kill -9 ${pid}`;
 
         await execPromise(killCommand);
-        console.log(`✓ Successfully freed up port ${port}`);
+        vlog(`✓ Successfully freed up port ${port}`);
         await wait(1000); // Wait for the port to be fully released
       }
     } else {
-      console.log(`Port ${port} is available.`);
+      vlog(`Port ${port} is available.`);
     }
     return true;
   } catch (error) {
@@ -108,37 +118,39 @@ const startServer = async (port = PORT) => {
   try {
     // If there's an existing server, close it properly first
     if (serverInstance) {
-      console.log("Closing existing server instance...");
+      vlog("Closing existing server instance...");
       await new Promise((resolve) => {
         serverInstance.close(() => {
-          console.log("Existing server closed");
+          vlog("Existing server closed");
           resolve();
         });
       });
       serverInstance = null;
     }
 
-    // Always try to free up port 3000 first
-    await freeUpPort(port);
+    // Free up the port if enabled
+    if (ENABLE_PORT_CLEANUP) {
+      await freeUpPort(port);
+    }
 
-    console.log(`Attempting to start server on port ${port}...`);
+    vlog(`Attempting to start server on port ${port}...`);
 
     // Create new server instance
     serverInstance = server.listen(port, () => {
-      console.log("✓ Server startup complete!");
+      vlog("✓ Server startup complete!");
       console.log(`🚀 Server running at http://localhost:${port}`);
-      console.log("Ready to accept connections");
+      vlog("Ready to accept connections");
     });
 
     // Handle server errors
     serverInstance.on("error", async (error) => {
       if (error.code === "EADDRINUSE") {
-        console.log(`⚠️  Port ${port} is still busy after attempt to free it.`);
-        console.log("Trying again to free up the port...");
+        vlog(`⚠️  Port ${port} is still busy after attempt to free it.`);
+        vlog("Trying again to free up the port...");
 
         const success = await freeUpPort(port);
         if (success) {
-          console.log("Retrying server startup...");
+          vlog("Retrying server startup...");
           await wait(1000);
           await startServer(port); // Try again with the same port
         } else {
@@ -154,10 +166,10 @@ const startServer = async (port = PORT) => {
     // Handle process termination
     const cleanup = async () => {
       if (serverInstance) {
-        console.log("Shutting down server...");
+        vlog("Shutting down server...");
         await new Promise((resolve) => {
           serverInstance.close(() => {
-            console.log("✓ Server closed");
+            vlog("✓ Server closed");
             resolve();
           });
         });
@@ -185,7 +197,7 @@ const startServer = async (port = PORT) => {
     return serverInstance;
   } catch (error) {
     console.error("❌ Failed to start server:", error);
-    console.log("Retrying in 2 seconds...");
+    vlog("Retrying in 2 seconds...");
     await wait(2000);
     return startServer(port); // Always retry with the same port
   }

--- a/backend/services/openai.js
+++ b/backend/services/openai.js
@@ -12,6 +12,13 @@ const {
 const path = require("path");
 const fs = require("fs");
 
+// Reusable OpenAI client and default model
+const openAIClient = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || "gpt-4o-mini";
+
 // Helper to validate skills structure
 function validateSkills(skills) {
   // Debug validation input
@@ -152,20 +159,18 @@ const openaiService = {
       infoLog("Starting stage: OpenAI");
       const startApi = performance.now();
 
-      // Log the API key being used (first few characters only for security)
-      const apiKey = process.env.OPENAI_API_KEY;
-      if (!apiKey) {
+      // Verify API key is present once at startup
+      if (!process.env.OPENAI_API_KEY) {
         errorLog("No OpenAI API key found in environment variables");
         throw new Error(
           "Missing OpenAI API key. Please set OPENAI_API_KEY in your .env file."
         );
       }
 
-      debugLog("Using API key starting with:", apiKey.substring(0, 10) + "...");
-
-      const openai = new OpenAI({
-        apiKey: apiKey,
-      });
+      debugLog(
+        "Using API key starting with:",
+        process.env.OPENAI_API_KEY.substring(0, 10) + "..."
+      );
 
       // Debug transcript type and content
       debugLog("OpenAI Input:", {
@@ -175,8 +180,8 @@ const openaiService = {
         sample: transcript?.substring(0, 100),
       });
 
-      const completion = await openai.chat.completions.create({
-        model: "gpt-4o-mini",
+      const completion = await openAIClient.chat.completions.create({
+        model: DEFAULT_MODEL,
         messages: [
           { role: "system", content: ANALYSIS_PROMPT },
           { role: "user", content: transcript },
@@ -366,7 +371,7 @@ const openaiService = {
 
       // Make API call
       const response = await openAIClient.chat.completions.create({
-        model: CONFIG.gptModel,
+        model: DEFAULT_MODEL,
         messages,
         temperature: 0.2,
         max_tokens: 2500,


### PR DESCRIPTION
## Summary
- initialize reusable OpenAI client and default model
- implement Supabase report/profile fetch endpoints
- make server startup logs and port cleanup toggles configurable
- add `.env.example` with required variables

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_683c87916e84832588c6a1f41d0085cc